### PR TITLE
Fix typo in gemspec

### DIFF
--- a/google-search_rank.gemspec
+++ b/google-search_rank.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["komagata@gmail.com"]
 
   spec.summary       = %q{Easy to get to Google Search ranks.}
-  spec.description   = %q{Easy to get to Google Search rankgs.}
+  spec.description   = %q{Easy to get to Google Search ranks.}
   spec.homepage      = "https://github.com/komagata/google-search_rank"
   spec.license       = "MIT"
 


### PR DESCRIPTION
just fixing a typo in `google-search_rank.gemspec`
